### PR TITLE
Adapt calculation of flats per building

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,6 @@ data/scenarios/*
 !data/scenarios/example.csv
 !data/scenarios/central_devices_example.csv
 !data/scenarios/info.txt
-districtgenerator.egg-info
 errorfile.txt
 *.bk
 *.log

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ data/scenarios/*
 !data/scenarios/example.csv
 !data/scenarios/central_devices_example.csv
 !data/scenarios/info.txt
+districtgenerator.egg-info
 errorfile.txt
 *.bk
 *.log

--- a/classes/users.py
+++ b/classes/users.py
@@ -4,14 +4,14 @@ import math
 import os
 import random as rd
 
+import functions.heating_profile_5R1C as heating
 import numpy as np
 import richardsonpy
 import richardsonpy.classes.appliance as app_model
 import richardsonpy.classes.lighting as light_model
 import richardsonpy.classes.stochastic_el_load_wrapper as wrap
-
-import functions.heating_profile_5R1C as heating
 from classes.profils import Profiles
+from scipy.stats import truncpareto
 
 
 class Users:
@@ -134,10 +134,19 @@ class Users:
             The TABULA building category "GMH" (given here as "AB") contains
             buildings with 13 or more flats.
             The range of flats per building and probability of occurence is not
-            given. An exponential distribution with beta = 1 is assumed, the values
-            are then scaled to be >=13.
+            given.
+            A truncated pareto distribution is assumed, where all values are between
+            13 and 100. Therefore, it is assumed that no house will have more than
+            100 flats.
             """
-            self.nb_flats = np.random.exponential(scale=1) + 13
+            max_flats = 100.0
+            min_flats = 12.0  # the `scale` is added to this, so it's effectively 13
+            scale = 1.0
+            b = 1.0
+            c = (max_flats - min_flats) / scale
+            nb_flats = truncpareto.rvs(b=b, c=c, loc=min_flats, scale=scale, size=1)
+            # round to nearest integer
+            self.nb_flats = round(nb_flats[0], 0)
 
     def generate_number_occupants(self):
         """

--- a/classes/users.py
+++ b/classes/users.py
@@ -96,7 +96,7 @@ class Users:
         None.
         """
         # SFH and TH have the same procedure
-        if self.building == "SFH" or "TH":
+        if self.building == "SFH" or self.building == "TH":
             """
             The TABLUA building category "SFH" and "TH" are comprised of
             houses with one flat and two flats.
@@ -146,7 +146,7 @@ class Users:
             c = (max_flats - min_flats) / scale
             nb_flats = truncpareto.rvs(b=b, c=c, loc=min_flats, scale=scale, size=1)
             # round to nearest integer
-            self.nb_flats = round(nb_flats[0], 0)
+            self.nb_flats = int(round(nb_flats[0], 0))
 
     def generate_number_occupants(self):
         """

--- a/classes/users.py
+++ b/classes/users.py
@@ -125,10 +125,10 @@ class Users:
                 random <= prob
             ):  # if the probability says we are in the smaller group of MFH
                 self.nb_flats = rd.randint(
-                    3, 7
+                    3, 6
                 )  # select value between 3 and 6 (inclusive) on random
             else:
-                self.nb_flats = rd.randint(7, 13)
+                self.nb_flats = rd.randint(7, 12)
         elif self.building == "AB":
             """
             The TABULA building category "GMH" (given here as "AB") contains

--- a/classes/users.py
+++ b/classes/users.py
@@ -103,9 +103,9 @@ class Users:
             The probability of having one or two flats is calculated from
             the german Zensus 2011 data.
             """
-            prob_sfh = 0.660  # probability of a SFH
-            random = np.random.uniform(low=0, high=1, size=None)  # get random value
-            if random <= prob_sfh:
+            prob = 0.793  # probability of a 1 flat SFH (2 flat = 1-0.793)
+            random = np.random.uniform(low=0, high=1, size=None)
+            if random <= prob:
                 self.nb_flats = 1
             else:
                 self.nb_flats = 2
@@ -119,10 +119,10 @@ class Users:
             category probability is known. Within the categories, a uniform
             distribution is assumed.
             """
-            prob_3_6 = 0.541  # probability of having 3 to 6 flats in the house
+            prob = 0.718  # probability of a 3-6 flat MFH
             random = np.random.uniform(low=0, high=1, size=None)  # get random value
             if (
-                random <= prob_3_6
+                random <= prob
             ):  # if the probability says we are in the smaller group of MFH
                 self.nb_flats = rd.randint(
                     3, 7


### PR DESCRIPTION
## What's this about?

Hey there,
looking through the great work of the district generator, I noticed that the calculation of the number of flats per building was (in my opinion) lacking a more scientific base. So I dug into the Zensus 2011 data, that the IWU used for the TABULA typical buildings and came up with a new heuristic. This is just a proposal, if you have other plans or this doesn't fit the goal of the software, I completely understand a refusal.

## How was it handled before?

Previously, the number of flats per SFH/TH building was hardcoded to 1. The number of flats for MFH/AB type buildings was either hardcoded or calculated from the buildings floor area, based on the assumption, that each flat has around 100m² of floor space.

## What was the problem with this implementation?

The problem (from my maybe limited point of view) was twofold:
1) SFH/TH building types can have up to two flats per building, according to the TABULA typical buildings study of IWU
2) The average flat size of MFH/AB type buildings is not 100m² according to the Zensus 2011 data (which the TABULA study is based on), but ~70m² for MFH and ~60m² for AB.

## How is it implemented now?

### SFH/TH

From the Zensus 2011 data ([Link](https://ergebnisse2011.zensus2022.de/datenbank/online)), I simply calculated the proportion of single and double appartment buildings within the SFH category. Based on these proportions and a random number between 0 and 1, it is decided if the building has one or two appartments. So the calculation is not based on the floor area anymore; the Zensus data shows that there are flats of every size in every category, from smaller than 30m² to larger than 180m².

### MFH

The TABULA building type MFH contains houses with 3 to 12 flats, but this range is split in two categories in the Zensus2011 data. So only the number of houses with 3-6 flats and 7-12 flats is known. I calculated the proportion of both categories and based on a random number, one of the two categories is selected. After that, the number of flats is chosen from a uniform distribution within the specified limits (i.e. between 3 and 6 flats and between 7 and 12 flats).

### AB

The Zensus dataset provides the least amount of information about appartment blocks. The only helpful thing to know is that there are flats of every size, so making a decision based on size does not feel appropriate to me. Therefore, I went out on a limb here and assumed a truncated pareto distribution, scaled to a minimum value of 13 (the TABULA category for AB is 13+ flats) and a maximum value of 100 (pure assumption on my part, definitely willing to change that). I've used `scipy.stats.truncpareto` for it, as scipy is already in the dependencies. The scaling factors `b` and `scale` are both set to 1. 
This is the most arbitrary decision and I am open to suggestions here. Seeing that AB type buildings only make up 1.2% of all buildings in Germany (according to Zensus dataset) I accepted the margin of error. For a project primarily concerned with AB type buildings, this might not be ideal. I wasn't able to find any more information on this distribution. Maybe the Zensus 2022 data will hold more detailled information.