### PR TITLE
Adapt calculation/generation of number inhabitants

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ data/scenarios/*
 !data/scenarios/example.csv
 !data/scenarios/central_devices_example.csv
 !data/scenarios/info.txt
+districtgenerator.egg-info
 errorfile.txt
 *.bk
 *.log

--- a/classes/users.py
+++ b/classes/users.py
@@ -78,7 +78,7 @@ class Users:
         self.generate_lighting_index()
         self.create_el_wrapper()
 
-    def generate_number_flats(self):
+    def generate_number_flats(self, area):
         """
         Generate number of flats for different of building types.
         Possible building types are:

--- a/classes/users.py
+++ b/classes/users.py
@@ -72,7 +72,7 @@ class Users:
         self.gains = None
         self.heat = None
 
-        self.generate_number_flats()
+        self.generate_number_flats(area)
         self.generate_number_occupants()
         self.generate_annual_el_consumption()
         self.generate_lighting_index()

--- a/classes/users.py
+++ b/classes/users.py
@@ -142,6 +142,9 @@ class Users:
     def generate_number_occupants(self):
         """
         Generate number of occupants for different of building types.
+        Number of inhabitants is always between 1 and 6, irrespective of
+        building type. The probability of a certain number of inhabitants
+        changes with building type, based on Zensus2011 data.
 
         Parameters
         ----------
@@ -152,61 +155,71 @@ class Users:
         None.
         """
 
-        if self.building == "SFH":
-            # choose random number of occupants (2-5) for single family houses (assumption)
-
+        if self.building in ("SFH", "TH"):
+            # probability table, calculated from Zensus2011
+            # k: number inhabitants
+            # v: proportion of occurence (cumulative)
+            prob = {
+                1: (0, 0.223),
+                2: (0.223, 0.581),
+                3: (0.581, 0.770),
+                4: (0.770, 0.927),
+                5: (0.927, 0.977),
+                6: (0.977, 1),
+            }
             # loop over all flats of current building
-            for j in range(self.nb_flats):
-                random_nb = rd.random()  # picking random number in [0,1)
-                j = 1  # staring with one (additional) occupant
-                # the random number decides how many occupants are chosen (2-5)
-                while j <= 4:
-                    if random_nb < j / 4:
-                        self.nb_occ.append(1 + j)  # minimum is 2 occupants
-                        break
-                    j += 1
-
-        if self.building == "TH":
-            # choose random number of occupants (2-5) for terraced houses (assumption)
-
-            # loop over all flats of current building
-            for j in range(self.nb_flats):
-                random_nb = rd.random()  # picking random number in [0,1)
-                j = 1  # staring with one (additional) occupant
-                # the random number decides how many occupants are chosen (2-5)
-                while j <= 4:
-                    if random_nb < j / 4:
-                        self.nb_occ.append(1 + j)  # minimum is 2 occupants
-                        break
-                    j += 1
+            for flat in range(self.nb_flats):
+                # get a random number
+                random_nb = rd.random()
+                for k, (lb, ub) in prob.items():
+                    # if the random number is between the lb and ub
+                    if random_nb > lb and random_nb < ub:
+                        # the key gives the number of occupants
+                        self.nb_occ.append(k)
 
         if self.building == "MFH":
-            # choose random number of occupants (1-4) for each flat in the multifamily house (assumption)
-
+            # probability table, calculated from Zensus2011
+            # k: number inhabitants
+            # v: proportion of occurence (cumulative)
+            prob = {
+                1: (0, 0.468),
+                2: (0.468, 0.794),
+                3: (0.794, 0.910),
+                4: (0.910, 0.973),
+                5: (0.973, 0.991),
+                6: (0.991, 1),
+            }
             # loop over all flats of current building
-            for j in range(self.nb_flats):
-                random_nb = rd.random()  # picking random number in [0,1)
-                k = 1
-                # the random number decides how many occupants are chosen (1-4)
-                while k <= 4:
-                    if random_nb < k / 4:
+            for flat in range(self.nb_flats):
+                # get a random number
+                random_nb = rd.random()
+                for k, (lb, ub) in prob.items():
+                    # if the random number is between the lb and ub
+                    if random_nb > lb and random_nb < ub:
+                        # the key gives the number of occupants
                         self.nb_occ.append(k)
-                        break
-                    k += 1
 
         if self.building == "AB":
-            # choose random number of occupants (1-4) for each flat in the apartment block  (assumption)
-
+            # probability table, calculated from Zensus2011
+            # k: number inhabitants
+            # v: proportion of occurence (cumulative)
+            prob = {
+                1: (0, 0.609),
+                2: (0.609, 0.858),
+                3: (0.858, 0.935),
+                4: (0.935, 0.978),
+                5: (0.978, 0.992),
+                6: (0.992, 1),
+            }
             # loop over all flats of current building
-            for j in range(self.nb_flats):
-                random_nb = rd.random()  # picking random number in [0,1)
-                k = 1
-                # the random number decides how many occupants are chosen (1-4)
-                while k <= 4:
-                    if random_nb < k / 4:
+            for flat in range(self.nb_flats):
+                # get a random number
+                random_nb = rd.random()
+                for k, (lb, ub) in prob.items():
+                    # if the random number is between the lb and ub
+                    if random_nb > lb and random_nb < ub:
+                        # the key gives the number of occupants
                         self.nb_occ.append(k)
-                        break
-                    k += 1
 
     def generate_annual_el_consumption(self):
         """

--- a/classes/users.py
+++ b/classes/users.py
@@ -80,7 +80,7 @@ class Users:
 
     def generate_number_flats(self):
         """
-        Generate number of flats for different building types.
+        Generate number of flats for different of building types.
         Possible building types are:
             - single family house (SFH)
             - terraced house (TH)
@@ -89,55 +89,28 @@ class Users:
 
         Parameters
         ----------
-        None.
+        area : integer
+            Floor area of different building types.
 
         Returns
         -------
         None.
         """
-        # SFH and TH have the same procedure
-        if self.building == "SFH" or "TH":
-            """
-            The TABLUA building category "SFH" and "TH" are comprised of
-            houses with one flat and two flats.
-            The probability of having one or two flats is calculated from
-            the german Zensus 2011 data.
-            """
-            prob = 0.793  # probability of a 1 flat SFH (2 flat = 1-0.793)
-            random = np.random.uniform(low=0, high=1, size=None)
-            if random <= prob:
-                self.nb_flats = 1
-            else:
-                self.nb_flats = 2
+
+        if self.building == "SFH":
+            self.nb_flats = 1
+        elif self.building == "TH":
+            self.nb_flats = 1
         elif self.building == "MFH":
-            """
-            The TABLUA building category "MFH" is comprised of houses with
-            three to 12 flats.
-            The probability of occurence of the amount of flats is calculated
-            from the german Zensus 2011 data. The number of flats per building
-            is given in categories (3-6 flats, 7-12 flats) and only the
-            category probability is known. Within the categories, a uniform
-            distribution is assumed.
-            """
-            prob = 0.718  # probability of a 3-6 flat MFH
-            random = np.random.uniform(low=0, high=1, size=None)  # get random value
-            if (
-                random <= prob
-            ):  # if the probability says we are in the smaller group of MFH
-                self.nb_flats = rd.randint(
-                    3, 7
-                )  # select value between 3 and 6 (inclusive) on random
-            else:
-                self.nb_flats = rd.randint(7, 13)
+            if area <= 4 * 100:
+                self.nb_flats = 4
+            elif area > 4 * 100:
+                self.nb_flats = math.floor(area / 100)
         elif self.building == "AB":
-            """
-            The TABULA building category "GMH" (given here as "AB") contains
-            buildings with 13 or more flats.
-            The range of flats per building and probability of occurence is not
-            given. An exponential distribution with beta = 1 is assumed, the values
-            are then scaled to be >=13.
-            """
-            self.nb_flats = np.random.exponential(scale=1) + 13
+            if area <= 10 * 100:
+                self.nb_flats = 10
+            elif area > 10 * 100:
+                self.nb_flats = math.floor(area / 100)
 
     def generate_number_occupants(self):
         """


### PR DESCRIPTION
## What's this about?

While working on [PR#7](https://github.com/RWTH-EBC/districtgenerator/pull/7), I came across data from Zensus2011 to improve the generation of occupant number per flat. As with the other PR: if this doesn't fit your schedule/plan, I completely understand a refusal.

## How was it handled before?

Previously, the number of occupants was selected on random from 2-5 (SFH&TH) or 1-4 (MFH&AB).

## What was the problem with this implementation?

There really was no problem per se. I just found data that supported a more differentiated selection to represent the conditions in Germany.

## How is it implemented now?

Zensus 2011 data lists the number of flats with a certan number of occupants (1 to 6+), sorted by the number of flats per building. The latter helps to sort the values according to the building type (SFH, TH, MFH, AB).
Considering SFH, taking the number of flats with 1 occupant and dividing it by the number of flats in SFH-buildings in total gives us the probability of a single person living in a flat of a SFH-type building. This is calculated for all building types. The corresponding probability values of a building type are then used to select the number of occupants in each flat of the building.

The category "6+ occupants" is considered as 6 occupants. Only 2.3/0.9/0.8 percent (!) of the flats of SFH-/MFH-/AB-type buildings fall into that category, respectively.