### PR TITLE
Fix #113: Prevent runtime warnings and NaNs in KPI cover factor calculations

### DIFF
--- a/districtgenerator/classes/KPIs.py
+++ b/districtgenerator/classes/KPIs.py
@@ -340,8 +340,19 @@ class KPIs:
                     nenner_sup[c, t] += b
                     min[c, t] = np.min([a, b])
 
-                self.demandCoverFactor[year][c] = np.sum(min[c, :]) / np.sum(nenner_dem[c, :])
-                self.supplyCoverFactor[year][c] = np.sum(min[c, :]) / np.sum(nenner_sup[c, :])
+                sum_min = np.sum(min[c, :])
+                sum_dem = np.sum(nenner_dem[c, :])
+                sum_sup = np.sum(nenner_sup[c, :])
+
+
+                self.demandCoverFactor[year][c] = np.divide(
+                sum_min, sum_dem,
+                out=np.ones_like(sum_min), where=(sum_dem != 0)
+                )
+                self.supplyCoverFactor[year][c] = np.divide(
+                sum_min, sum_sup,
+                out=np.zeros_like(sum_min), where=(sum_sup != 0)
+                )
 
         # Calculate weighted average over all years
 


### PR DESCRIPTION
Replaced direct division with `np.divide` to safely handle scenarios where the denominator for demand or supply cover factors is zero. This prevents `RuntimeWarning` and `NaN` values, ensuring defined outputs (1 for demand cover factor, 0 for supply cover factor) in these edge cases.
